### PR TITLE
Default charset defined as UTF-8 and iconv method converts iff needed

### DIFF
--- a/src/BaseException.php
+++ b/src/BaseException.php
@@ -1102,6 +1102,11 @@ class BaseException extends Exception implements IBaseException{
 
 		$iconv = function($string){
 
+			if(mb_detect_encoding($string,'Windows-1252, UTF-8, ISO-8859-1') === 'UTF-8'){
+				
+				return $string;
+			}
+			
 			return @iconv('Windows-1252', 'UTF-8//TRANSLIT', $string);
 		};
 

--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -45,7 +45,7 @@ namespace StudyPortals\Exception;
 
 if(!defined('DEFAULT_CHARSET')){
 
-	define('DEFAULT_CHARSET', 'ISO-8859-1');
+	define('DEFAULT_CHARSET', 'UTF-8');
 }
 
 /**


### PR DESCRIPTION
# Part of switching the Portals to UTF-8 
For the general description of the process, please refer to: https://github.com/studyportals/Framework/pull/64 
## Purpose
Since we are preparing for the UTF-8 switch in the Portals this method should be aligned with the utf-8 charset serving for the client.  
So in order to allow for charset decoding if needed, the method `iconv` does not attempt to decode the already UTF-8 encoded strings. 
### To see in action 
This branch is referenced as a submodule in the Bachelors [AF-SwitchToUTF8](https://github.com/studyportals/Bachelors/tree/AF-SwitchToUTF8)